### PR TITLE
Get HOOK_DIR more reliably/portable

### DIFF
--- a/contrib/pre-commit-hook-static-dba-files.sh
+++ b/contrib/pre-commit-hook-static-dba-files.sh
@@ -35,7 +35,7 @@ exit_if_err() {
 # be performed.
 
 ORIG_DIR=$(pwd)
-HOOK_DIR=$(dirname $(readlink $0))
+HOOK_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 cd $HOOK_DIR
 
 STAGED_FILES=$(cd $ORIG_DIR && git diff --cached --name-only --relative --diff-filter=ACMR)


### PR DESCRIPTION
http://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself
the readlink command was failing when I tried running this, presumably b/c it's missing the -f flag. However, after poking around I found the above SO question which seems to indicate that this is a more portable solution since readlink is apparently not POSIX.