### PR TITLE
resolves #11 - base config + overrides

### DIFF
--- a/schematool/command/context.py
+++ b/schematool/command/context.py
@@ -34,6 +34,28 @@ class CommandContext:
 
         return CommandContext(config, db)
 
+    @staticmethod
+    def validate_config(config):
+        """
+        Given a config, check for the required fields. Return the array
+        of errors that are encountered. A valid configuration should return
+        an empty array.
+        """
+        errors = []
+        if not 'type' in config:
+            errors.append("Missing config value 'type'")
+        if not 'host' in config:
+            errors.append("Missing config value 'host'")
+        if not 'revision_db_name' in config:
+            errors.append("Missing config value 'revision_db_name'")
+        if not 'history_table_name' in config:
+            errors.append("Missing config value 'history_table_name'")
+
+        if 'password' in config and not 'username' in config:
+            errors.append("'username' missing when 'password' provided")
+
+        return errors
+
     def __init__(self, config, DB):
         self.config = config
         self.db = DB

--- a/schematool/constants.py
+++ b/schematool/constants.py
@@ -3,6 +3,7 @@ import re
 
 class Constants(object):
     ALTER_DIR = os.path.abspath(os.path.curdir) + os.path.sep
+    BASE_CONFIG_FILE = os.path.join(os.path.expanduser("~"), '.schema-tool')
     CONFIG_FILE = os.path.join(ALTER_DIR, 'config.json')
     COMMANDS = [
         {'command': 'new',      'handler': 'NewCommand'},


### PR DESCRIPTION
Introduces a base-configuration file, read from ~/.schema-tool
which can be overriden by project-configs (the config.json within
the project itself). This allows you to declutter your config
files for people managing multiple schema-repositories on a single
machine.

As an added bonus, the config loading was moved around so that you
can view the help file without having to load a config first, and thus
having to be within a project folder.