### PR TITLE
[BUG] Postgres interface uses db_name instead of revision_db_name

### DIFF
--- a/schematool/db/_pg.py
+++ b/schematool/db/_pg.py
@@ -149,7 +149,7 @@ class PostgresDb(Db):
                     elif key == 'password':
                         conn_string_parts.append('password=%s')
                         conn_string_params.append(value)
-                    elif key == 'db_name':
+                    elif key == 'revision_db_name':
                         conn_string_parts.append('dbname=%s')
                         conn_string_params.append(value)
             conn_string = ' '.join(conn_string_parts) % tuple(conn_string_params)


### PR DESCRIPTION
db_name = database name where the alters are to be applied
revision_db_name = database name where the revision history is tracked

With the bug present, revision_db_name field is ignored and history changes still get stored at db_name.
Bug's effect isn't noticed if both database names are the same which is what's been the case up till now.