### PR TITLE
mysql config's port was not used everywhere

### DIFF
--- a/schematool/db/_mysql.py
+++ b/schematool/db/_mysql.py
@@ -160,5 +160,7 @@ class MySQLDb(Db):
                '-u', cls.config['username']]
         if cls.config.get('password'):
             cmd.append('-p%s' % cls.config['password'])
+        if cls.config.get('port'):
+            cmd.append('-P%s' % cls.config['port'])
         my_env = None
         return cmd, my_env


### PR DESCRIPTION
Port was used by direct connection from the code but not when executing
the mysql shell command (defaulting to 3306).
When using a port != 3306, schema history was correctly read, but
applying alters was impossible