### PR TITLE
Add Hive support

### DIFF
--- a/README
+++ b/README
@@ -27,7 +27,9 @@ is an excellent DSL already, so there is no need for that.
 ## Requirements
 
 + Python 2.7 (may work with other versions, only tested against 2.7)
-+ [`psycopg2`][3] installed if you plan to use with Postgres
++ [`psycopg2`][3] if planning to use Schema Tool with Postgres
++ [`vertica-python`][6] and [`psycopg2`][3] (required by Vertica python) if planning to use Schema Tool with Vertica
++ [`pyhs2`][7] if planning to use Schema Tool with Hive
 
 ## Getting Started
 
@@ -323,3 +325,5 @@ See LICENSE file
   [3]: https://github.com/psycopg/psycopg2
   [4]: https://github.com/blog/1386-closing-issues-via-commit-messages
   [5]: https://github.com/appnexus/schema-tool/graphs/contributors
+  [6]: https://pypi.python.org/pypi/vertica-python/
+  [7]: https://github.com/BradRuderman/pyhs2

--- a/conf/config.json.hive-template
+++ b/conf/config.json.hive-template
@@ -1,0 +1,12 @@
+{
+    "username": "test",
+    "password": "test",
+    "host": "localhost",
+    "revision_db_name": "revision",
+    "history_table_name": "history",
+	"port": 10000,
+    "type": "hive",
+    "db_name": "myhivedb",
+    "pre_commit_hook": "relative/path/to-pre-commit-hook.sh",
+    "static_alter_dir": "relative/path/to-static-alters/"
+}

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@ is an excellent DSL already, so there is no need for that.
 + Python 2.7 (may work with other versions, only tested against 2.7)
 + [`psycopg2`][3] if planning to use Schema Tool with Postgres
 + [`vertica-python`][6] and [`psycopg2`][3] (required by Vertica python) if planning to use Schema Tool with Vertica
++ [`pyhs2`][7] if planning to use Schema Tool with Hive
 
 ## Getting Started
 
@@ -328,4 +329,4 @@ See LICENSE file
   [4]: https://github.com/blog/1386-closing-issues-via-commit-messages
   [5]: https://github.com/appnexus/schema-tool/graphs/contributors
   [6]: https://pypi.python.org/pypi/vertica-python/
-
+  [7]: https://github.com/BradRuderman/pyhs2

--- a/schematool/command/context.py
+++ b/schematool/command/context.py
@@ -1,5 +1,5 @@
 # local imports
-from db import MySQLDb, PostgresDb, VerticaDb, MemoryDb
+from db import MySQLDb, PostgresDb, MemoryDb, VerticaDb, HiveDb
 from errors import InvalidDBTypeError
 
 class CommandContext(object):
@@ -28,9 +28,11 @@ class CommandContext(object):
                 db = VerticaDb.new(config)
             elif config['type'] == 'memory-db':
                 db = MemoryDb.new(config)
+            elif config['type'] == 'hive':
+                db = HiveDb.new(config)
             else:
                 raise InvalidDBTypeError("Invalid database type in config. Only "
-                                         "'postgres' and 'mysql' are allowed.")
+                                         "'postgres', 'mysql', 'vertica', and 'hive' are allowed.")
         else:
             db = MySQLDb.new(config)
 

--- a/schematool/db/__init__.py
+++ b/schematool/db/__init__.py
@@ -1,4 +1,5 @@
+from _hive import HiveDb
+from _memory import MemoryDb
 from _mysql import MySQLDb
 from _pg import PostgresDb
 from _vertica import VerticaDb
-from _memory import MemoryDb

--- a/schematool/db/_hive.py
+++ b/schematool/db/_hive.py
@@ -1,0 +1,175 @@
+import os
+import tempfile
+from datetime import datetime
+
+# third-party imports
+try:
+    import pyhs2 as hive
+    from pyhs2.error import Pyhs2Exception
+except ImportError:
+    pass
+
+# local imports
+from db import Db
+from errors import DbError, InitError
+
+class HiveDb(Db):
+    DEFAULT_PORT = 10000
+    DUMMY_ALTER_REF = '000000000000'
+    HIVE_INIT_FILENAME = 'schema_tool_hive_init.tsv'
+
+    @classmethod
+    def new(cls, config):
+        super(HiveDb, cls).new(config)
+        if 'revision_db_name' in cls.config and 'history_table_name' in cls.config:
+            cls.db_name = '`%s`' % cls.config['revision_db_name']
+            cls.history_table_name = cls.config['history_table_name']
+            cls.full_table_name = '`%s`.`%s`' % (cls.config['revision_db_name'],
+                                                 cls.config['history_table_name'])
+        else:
+            raise DbError('No history schema found in config file. Please add values for the '
+                          'following keys: revision_db_name, history_table_name\n')
+
+        return cls
+
+    @classmethod
+    def init_conn(cls):
+        try:
+            hive
+        except NameError:
+            raise DbError('Hive client module not found/loaded. Please make sure all dependencies are installed\n')
+
+        cls.conn = cls.conn()
+        cls.cursor = cls.conn.cursor()
+
+        cls.conn_initialized = True
+        return cls
+
+    @classmethod
+    def execute(cls, query, data=None):
+        if not cls.conn_initialized:
+            cls.init_conn()
+
+        cursor = cls.cursor
+        results = []
+        try:
+            if data:
+                cursor.execute(query % data)
+            else:
+                cursor.execute(query)
+
+            results = cursor.fetch()
+            return results
+        except Pyhs2Exception, e:
+            raise DbError('Could not query DB. Exception:\n%s\n\nQuery:%s' % (e, query))
+
+    @classmethod
+    def drop_revision(cls):
+        return cls.execute('DROP DATABASE IF EXISTS %s' % cls.config['revision_db_name'])
+
+    @classmethod
+    def create_revision(cls):
+        # Executing 'CREATE DATABASE IF NOT EXISTS' fails if the user does not
+        # have database creation privileges, even if the database already exists.
+        # The correct action is to break this method into two parts: checking
+        # if the database exists, and then creating it only if it does not.
+        #
+        # The 'IF NOT EXISTS' flag is still used in case the database is
+        # created after the existence check but before the CREATE statement.
+        check = 'SHOW DATABASES LIKE "%s"' % cls.config['revision_db_name']
+        results = cls.execute(check)
+        if len(results):
+            return
+        else:
+            return cls.execute('CREATE DATABASE IF NOT EXISTS %s' % cls.config['revision_db_name'])
+
+    @classmethod
+    def get_commit_history(cls):
+        # Omit the placeholder row
+        return cls.execute('SELECT * FROM %s WHERE alter_hash != \'%s\'' %
+            (cls.full_table_name, cls.DUMMY_ALTER_REF))
+
+    @classmethod
+    def append_commit(cls, ref):
+        return cls.execute(cls.get_append_commit_query(ref))
+
+    @classmethod
+    def get_append_commit_query(cls, ref):
+        ran_on = datetime.strftime(datetime.now(), '%Y-%m-%d %H:%M:%S')
+        return ("""INSERT OVERWRITE TABLE %s SELECT t.alter_hash, t.ran_on FROM
+                   (SELECT alter_hash, ran_on FROM %s UNION ALL
+                   SELECT '%s' AS alter_hash, '%s' AS ran_on FROM %s LIMIT 1) t""" %
+            (cls.full_table_name, cls.full_table_name, ref, ran_on, cls.full_table_name))
+
+    @classmethod
+    def remove_commit(cls, ref):
+        return cls.execute(cls.get_remove_commit_query(ref))
+
+    @classmethod
+    def get_remove_commit_query(cls, ref):
+        return ("""INSERT OVERWRITE TABLE %s SELECT t.alter_hash, t.ran_on FROM %s t
+                   WHERE t.alter_hash != '%s'""" % (cls.full_table_name, cls.full_table_name, ref))
+
+    @classmethod
+    def create_history(cls):
+        create_table_result = cls.execute("""CREATE TABLE IF NOT EXISTS %s (
+                                                alter_hash string,
+                                                ran_on timestamp
+                                            ) ROW FORMAT DELIMITED FIELDS TERMINATED BY '\t'
+                                            STORED AS TEXTFILE""" % cls.full_table_name)
+
+        # Check whether table has been bootstrapped with the intial placeholder entry
+        results = cls.execute('SELECT * FROM %s WHERE alter_hash = \'%s\'' %
+            (cls.full_table_name, cls.DUMMY_ALTER_REF))
+
+        if not results:
+            # Create a tab-separated file that will be used to seed the history table, and attempt
+            # to load it via Hive
+            init_file_path = os.path.join(tempfile.gettempdir(), cls.HIVE_INIT_FILENAME)
+            with open(init_file_path, 'w') as f:
+                ran_on = datetime.strftime(datetime.now(), '%Y-%m-%d %H:%M:%S')
+                f.write('%s\t%s\n' % (cls.DUMMY_ALTER_REF, ran_on))
+            os.chmod(init_file_path, 0666)
+
+            try:
+                # Since the file was created on the local filesystem and the Hive client will execute
+                # the following operation such that all local paths are relative to the Hive server's
+                # filesystem, this will only work if the Hive server is running locally.
+                # Try to load the file anyway - otherwise, warn the user that this step must be done
+                # manually
+                cls.execute("LOAD DATA LOCAL INPATH '%s' OVERWRITE INTO TABLE %s" %
+                    (init_file_path, cls.full_table_name))
+            except DbError, e:
+                raise InitError('Unable to initialize history table. If you are pointing to a Hive '
+                    'server running on a remote host, please copy the file \'%s\' to the same path '
+                    'on the Hive server host and re-run the \'init\' command.\n%s' %
+                    (init_file_path, e.message))
+
+        return create_table_result
+
+    @classmethod
+    def conn(cls):
+        """
+        return the hive connection handle to the configured server
+        """
+        config = cls.config
+        try:
+            connection = hive.connect(host=config['host'], port=config.get('port', cls.DEFAULT_PORT),
+                                      authMechanism='NOSASL', user=config['username'],
+                                      password=config['password'], database=config['db_name'])
+        except Exception, e:
+            raise DbError("Cannot connect to Hive Server: %s\n"
+                          "Ensure that the server is running and you can connect normally"
+                          % e.message)
+
+        return connection
+
+    @classmethod
+    def run_file_cmd(cls):
+        port = cls.config.get('port', cls.DEFAULT_PORT)
+        jdbc_url = 'jdbc:hive2://%s:%s/%s' % (cls.config['host'], port, cls.config['db_name'])
+        # TODO: fix this
+        cmd = ['beeline',
+               '-u', jdbc_url]
+        my_env = None
+        return cmd, my_env

--- a/schematool/db/_hive.py
+++ b/schematool/db/_hive.py
@@ -173,12 +173,19 @@ class HiveDb(Db):
         return connection
 
     @classmethod
-    def run_file_cmd(cls):
+    def run_file_cmd(cls, filename):
+        """
+        return a 3-tuple of strings containing:
+            the command to run (list)
+            environment variables to be passed to command (dictionary or None)
+            data to be piped into stdin (file-like object or None)
+        """
         port = cls.config.get('port', cls.DEFAULT_PORT)
         jdbc_url = 'jdbc:hive2://%s:%s/default;auth=noSasl' % (cls.config['host'], port)
-        # Beeline is the recommended Hive command-line client
+
+        # Beeline is the recommended command-line client for HiveServer2
         cmd = ['beeline', '-u', jdbc_url,
                '-n', cls.config['username'],
-               '-p', cls.config['password']]
-        my_env = None
-        return cmd, my_env
+               '-p', cls.config['password'],
+               '-f', filename]
+        return cmd, None, None

--- a/schematool/db/_memory.py
+++ b/schematool/db/_memory.py
@@ -63,9 +63,21 @@ class MemoryDb(Db):
         return cls
 
     @classmethod
-    def run_file_cmd(cls):
-        return ['/bin/true'], None
+    def run_file_cmd(cls, filename):
+        """
+        return a 3-tuple of strings containing:
+            the command to run (list)
+            environment variables to be passed to command (dictionary or None)
+            data to be piped into stdin (file-like object or None)
+        """
+        return ['/bin/true'], None, None
 
     @classmethod
-    def run_file_cmd_with_error(cls):
-        return ['/bin/false'], None
+    def run_file_cmd_with_error(cls, filename):
+        """
+        return a 3-tuple of strings containing:
+            the command to run (list)
+            environment variables to be passed to command (dictionary or None)
+            data to be piped into stdin (file-like object or None)
+        """
+        return ['/bin/false'], None, None

--- a/schematool/db/_mysql.py
+++ b/schematool/db/_mysql.py
@@ -154,7 +154,13 @@ class MySQLDb(Db):
         return conn
 
     @classmethod
-    def run_file_cmd(cls):
+    def run_file_cmd(cls, filename):
+        """
+        return a 3-tuple of strings containing:
+            the command to run (list)
+            environment variables to be passed to command (dictionary or None)
+            data to be piped into stdin (file-like object or None)
+        """
         cmd = ['mysql',
                '-h', cls.config['host'],
                '-u', cls.config['username']]
@@ -163,4 +169,4 @@ class MySQLDb(Db):
         if cls.config.get('port'):
             cmd.append('-P%s' % cls.config['port'])
         my_env = None
-        return cmd, my_env
+        return cmd, my_env, open(filename)

--- a/schematool/db/_pg.py
+++ b/schematool/db/_pg.py
@@ -167,7 +167,13 @@ class PostgresDb(Db):
         return conn
 
     @classmethod
-    def run_file_cmd(cls):
+    def run_file_cmd(cls, filename):
+        """
+        return a 3-tuple of strings containing:
+            the command to run (list)
+            environment variables to be passed to command (dictionary or None)
+            data to be piped into stdin (file-like object or None)
+        """
         port_number = str(cls.config.get('port', PostgresDb.DEFAULT_PORT))
         cmd = ['psql',
                '-h', cls.config['host'],
@@ -181,4 +187,4 @@ class PostgresDb(Db):
         if 'password' in cls.config:
             my_env = os.environ.copy()
             my_env['PGPASSWORD'] = cls.config['password']
-        return cmd, my_env
+        return cmd, my_env, open(filename)

--- a/schematool/db/_vertica.py
+++ b/schematool/db/_vertica.py
@@ -156,7 +156,13 @@ class VerticaDb(Db):
         return conn
 
     @classmethod
-    def run_file_cmd(cls):
+    def run_file_cmd(cls, filename):
+        """
+        return a 3-tuple of strings containing:
+            the command to run (list)
+            environment variables to be passed to command (dictionary or None)
+            data to be piped into stdin (file-like object or None)
+        """
         port_number = str(cls.config.get('port', VerticaDb.DEFAULT_PORT))
         cmd = ['/opt/vertica/bin/vsql',
                '-h', cls.config['host'],
@@ -171,4 +177,4 @@ class VerticaDb(Db):
         if 'password' in cls.config:
             my_env = os.environ.copy()
             my_env['VSQL_PASSWORD'] = cls.config['password']
-        return cmd, my_env
+        return cmd, my_env, open(filename)

--- a/schematool/db/db.py
+++ b/schematool/db/db.py
@@ -64,17 +64,26 @@ class Db(object):
     def _run_file(cls, filename, exit_on_error=True, verbose=False):
         # Used for testing to simulate an error in the running of an alter file
         if getattr(cls, 'auto_throw_error', False) and 'error' in filename:
-            command, my_env = cls.run_file_cmd_with_error()
+            command, my_env, stdin_stream = cls.run_file_cmd_with_error(filename)
         else:
-            command, my_env = cls.run_file_cmd()
-        proc = subprocess.Popen(command,
-                                stdin=subprocess.PIPE,
-                                stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE,
-                                env=my_env)
+            command, my_env, stdin_stream = cls.run_file_cmd(filename)
 
-        script = open(filename)
-        out, err = proc.communicate(script.read())
+        if stdin_stream:
+            proc = subprocess.Popen(command,
+                                    stdin=subprocess.PIPE,
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE,
+                                    env=my_env)
+
+            script = open(filename)
+            out, err = proc.communicate(script.read())
+        else:
+            proc = subprocess.Popen(command,
+                                    stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE,
+                                    env=my_env)
+            out, err = proc.communicate()
+
         if err:
             sys.stderr.write("\n----------------------\n")
             sys.stderr.write(out.rstrip())

--- a/schematool/errors.py
+++ b/schematool/errors.py
@@ -42,3 +42,6 @@ class HeadError(Exception):
 
 class CircularRefError(Exception):
     pass
+
+class InitError(Exception):
+    pass


### PR DESCRIPTION
Support management of Hive schemas for Hadoop/HDFS-based data stores.

Changes:
 * Add a new db module that uses the pyhs2 module to execute Hive queries
 * Refactor the run_file_cmd function to not assume that the contents of the SQL file can always be piped into stdin
 * Update supporting modules and docs
 * Add sample config template for Hive