### PR TITLE
Fixing dict parsing

### DIFF
--- a/schematool/command/down.py
+++ b/schematool/command/down.py
@@ -61,7 +61,7 @@ class DownCommand(Command):
         down_alters_to_run = []
         max_history_len = int(options.N or len(history))
         i = 0
-        for (_, alter_id, _) in history:
+        for (_, alter_id, _) in history.iteritems():
             if i == max_history_len:
                 break
             if run_type == 'base':

--- a/schematool/command/up.py
+++ b/schematool/command/up.py
@@ -64,7 +64,7 @@ class UpCommand(Command):
 
         # find (and remove) synced alters from alter_list (so they are not run again)
         common_history = 0
-        for (_, alter_id, _) in history:
+        for (_, alter_id, _) in history.iteritems():
             if len(alter_list) == 0:
                 break
             # don't count alters for other env's in common-history
@@ -84,7 +84,7 @@ class UpCommand(Command):
             if len(uncommon_history) > 0:
                 # clean up alters from here
                 uncommon_history.reverse()
-                for (_, alter_id, _) in uncommon_history:
+                for (_, alter_id, _) in uncommon_history.iteritems():
                     alters = [a for a in alter_list if a.id == alter_id]
                     if len(alters) > 1:
                         msg = "Multiple alters found for a single id (%s)" % alter_id


### PR DESCRIPTION
Fixing dict for loop iterator to prevent value error when it has too many values to unpack.

Stack Trace:
```
Traceback (most recent call last):
  File "/usr/bin/schema", line 95, in main
    globals()[handler](context).run()
  File "/usr/local/adnxs/schema-tool/schematool/command/up.py", line 67, in run
    for (_, alter_id, _) in history:
ValueError: too many values to unpack
```